### PR TITLE
Upgrade url-parse dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bluebird": "^3.1.1",
     "lodash": "^3.6.0",
     "superagent": "^1.1.0",
-    "url-parse": "^1.0.5",
+    "url-parse": "^1.4.7",
     "url-pattern": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrading `url-parse` dependency to pick-up a security fix that was causing a red-flag in our scans.
@maroshii can you take a look and publish a new version if this looks fine?

Signed-off-by: Emre Bogazliyanlioglu <ebogazliyanlioglu@mirantis.com>